### PR TITLE
Added ability to throw kwargs at the Client constructor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,13 @@ Valid columns by data set:
 * `ACS <http://www.census.gov/developers/data/2010acs5_variables.xml>`_
 * `SF1 <http://www.census.gov/developers/data/sf1.xml>`_
 
+You can pass additional keyword arguments to Census(), they will be used to
+invoke the requests.session() object. For example, a timeout of one second::
+
+    from census import Census
+
+    c = Census("MY_API_KEY", timeout=1.0)
+
 
 Geometries
 ==========

--- a/census/core.py
+++ b/census/core.py
@@ -20,8 +20,11 @@ class CensusException(Exception):
 
 class Client(object):
 
-    def __init__(self, key):
-        self._session = requests.session(params={'key': key})
+    def __init__(self, key, **kwargs):
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        kwargs['params']['key'] = key
+        self._session = requests.session(**kwargs)
         self._key = key
 
     def fields(self, flat=False):
@@ -162,6 +165,6 @@ class SF1Client(Client):
 
 class Census(object):
 
-    def __init__(self, key):
-        self.acs = ACSClient(key)
-        self.sf1 = SF1Client(key)
+    def __init__(self, key, **kwargs):
+        self.acs = ACSClient(key, **kwargs)
+        self.sf1 = SF1Client(key, **kwargs)


### PR DESCRIPTION
It would be nice to have the ability to adjust the behavior of the requests.Session object. This pull request contains a patch to census/core.py that gives that ability.

The specific use case I had in mind is described in README.rst, it would be nice to be able to set a global timeout to the client.

Disclaimer: I have not tested this patch at all, as I don't personally work with this library.
