### PR TITLE
Add dataset for new ACS 1 year data profiles. Update to version .6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,10 @@ The default year may also be set client-wide::
 Datasets
 ========
 
-* ACS (2011, 2010)
-* SF1 (2010, 2000, 1990)
-* SF3 (2000, 1990)
+* ACS5: ACS 5 Year Estimates (2011, 2010)
+* ACS1DP: ACS 1 Year Estimates, Data Profiles (2012)
+* SF1: Census Summary File 1 (2010, 2000, 1990)
+* SF3: Census Summary File 3 (2000, 1990)
 
 
 Geographies
@@ -64,7 +65,7 @@ with a year that is not supported will raise census.UnsupportedYearException.*
 
 `Geographic relationship files <http://www.census.gov/geo/maps-data/data/relationship.html>`_ are provided on the Census developer site as a tool to help users compare the geographies from the 1990, 2000 and 2010 Censuses. From these files, data users may determine how geographies from one Census relate to those from the prior Census.
 
-ACS Geometries
+ACS5 Geographies
 --------------
 
 * state(fields, state_fips)
@@ -76,7 +77,14 @@ ACS Geometries
 * us(fields)
 * zipcode(fields, zip5)
 
-SF1 Geometries
+ACS1 Geographies
+--------------
+
+* state(fields, state_fips)
+* state_district(fields, state_fips, district)
+* us(fields)
+
+SF1 Geographies
 --------------
 
 * state(fields, state_fips)


### PR DESCRIPTION
Hi Sunlight!

Made some updates to your helpful Census Python wrapper to include new API goodies released on 9/20: data profile tables for 1-year ACS estimates. Sending them your way in case it's helpful for others.

The code handles 2012 ACS 1-year requests only--does not include the 2011 ACS-1 year requests, which are available for congressional districts only and are formatted a bit differently.
