### PR TITLE
check for invalid api key message when json fails to parse

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -26,6 +26,13 @@ DEFINITIONS = {
     },
 }
 
+class APIKeyError(Exception):
+    '''Invalid API Key'''
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
 
 def list_or_str(v):
     """ Convert a single value into a list.
@@ -125,8 +132,13 @@ class Client(object):
         resp = self.session.get(url, params=params, headers=headers)
 
         if resp.status_code == 200:
-
-            data = json.loads(resp.text)
+            try:
+                data = json.loads(resp.text)
+            except ValueError as ex:
+                if '<title>Invalid Key</title>' in resp.text:
+                    raise APIKeyError(' '.join(resp.text.splitlines()))
+                else:
+                    raise ex
 
             headers = data[0]
             return [dict(zip(headers, d)) for d in data[1:]]


### PR DESCRIPTION
When json.loads() raises a ValueError, the reason may be that
the submitted FCC API Key was invalid. The FCC returns a small
html page titled "Invalid Key". This change checks for that
string in the response text and raises a more useful error
than a json parsing failure. If that text is not present, it
raises the original json parsing ValueError.
