### PR TITLE
Use >= for install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
-    install_requires=['requests==1.1.0', 'us==0.7'],
+    install_requires=['requests>=1.1.0', 'us>=0.7'],
 )


### PR DESCRIPTION
The currently listed requirements are getting a bit old and it's hard to resolve them
with the requirements in other libraries.
