### PR TITLE
switch to https endpoint

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -60,8 +60,8 @@ class UnsupportedYearException(CensusException):
 
 
 class Client(object):
-    endpoint_url = 'http://api.census.gov/data/%s/%s'
-    definitions_url = 'http://api.census.gov/data/%s/%s/variables.json'
+    endpoint_url = 'https://api.census.gov/data/%s/%s'
+    definitions_url = 'https://api.census.gov/data/%s/%s/variables.json'
 
     def __init__(self, key, year=None, session=None):
         self._key = key


### PR DESCRIPTION
The Census is deprecating its HTTP endpoint. All calls to the old HTTP endpoint should be switched to HTTPS. See the link below for details.

https://content.govdelivery.com/attachments/USCENSUS/2017/05/31/file_attachments/824523/HttpsChangeDocument.pdf