### PR TITLE
Added fix and test to focus on character encoding bug caused by La Cañada Flintridge city, California

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -1,3 +1,4 @@
+import six
 import warnings
 from functools import wraps
 
@@ -119,7 +120,6 @@ class Client(object):
 
 
     def query(self, fields, geo, year=None, **kwargs):
-
         if year is None:
             year = self.default_year
 
@@ -166,10 +166,10 @@ class Client(object):
         url = self.definition_url % (year, self.dataset, field)
         resp = self.session.get(url)
 
-        types = {"fips-for" : str,
-                 "fips-in" : str,
+        types = {"fips-for" : six.text_type,
+                 "fips-in" : six.text_type,
                  "int" : float_or_str,
-                 "string": str}
+                 "string": six.text_type}
 
         if resp.status_code == 200:
             predicate_type = resp.json().get("predicateType", "string")
@@ -211,14 +211,14 @@ class Client(object):
 class ACSClient(Client):
 
     def _switch_endpoints(self, year):
-        
+
         if year > 2015:
             self.endpoint_url = 'https://api.census.gov/data/%s/acs/%s'
             self.definitions_url = 'https://api.census.gov/data/%s/acs/%s/variables.json'
             self.definition_url = 'https://api.census.gov/data/%s/acs/%s/variables/%s.json'
         else:
-            self.endpoint_url = super(ACSClient, self).endpoint_url 
-            self.definitions_url = super(ACSClient, self).definitions_url 
+            self.endpoint_url = super(ACSClient, self).endpoint_url
+            self.definitions_url = super(ACSClient, self).definitions_url
             self.definition_url = super(ACSClient, self).definition_url
 
     def get(self, *args, **kwargs):

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import os
+import six
 import time
 import unittest
 from contextlib import closing
@@ -81,6 +84,36 @@ class TestUnsupportedYears(CensusTestCase):
         client = self.client('sf3')
         self.assertRaises(UnsupportedYearException,
                           client.state, ('NAME', '06'))
+
+
+class TestEncoding(CensusTestCase):
+    """
+    Test character encodings of results are properly handled.
+    """
+    def test_la_canada_2015(self):
+        """
+        The 'La Cañada Flintridge city, California' place can be a problem in Python 2.7.
+        """
+        # 2017 and 2016 is returned as:
+        # 'La Ca?ada Flintridge city, California'
+        geo = {
+            'for': 'place:39003',
+            'in': u'state:06'
+        }
+        self.assertEqual(
+            self._client.acs5.get('NAME', geo=geo)[0]['NAME'],
+            'La Ca?ada Flintridge city, California'
+        )
+        self.assertEqual(
+            self._client.acs.get('NAME', geo=geo, year=2016)[0]['NAME'],
+            'La Ca?ada Flintridge city, California'
+        )
+        # 2015 is returned as:
+        # 'La Ca\xf1ada Flintridge city, California'
+        self.assertEqual(
+            self._client.acs.get('NAME', geo=geo, year=2015)[0]['NAME'],
+            six.u('La Ca\xf1ada Flintridge city, California')
+        )
 
 
 class TestEndpoints(CensusTestCase):
@@ -211,6 +244,6 @@ class TestEndpoints(CensusTestCase):
         assert res_2016_2016 == res_2014_2016
         assert res_2014_2014 == res_2016_2014
 
-        
+
 if __name__ == '__main__':
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=2.9
+six

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=['requests>=1.1.0',
-                      'six',
+                      'six>=1.11.0',
                       'backports.functools_lru_cache;python_version<"3.3"'],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=['requests>=1.1.0',
+                      'six',
                       'backports.functools_lru_cache;python_version<"3.3"'],
 )


### PR DESCRIPTION
 The test we've added will fail on the master branch in Python 2.7. Any queries including the "place" of "La Cañada Flintridge city, California" for the 2015 ACS data now fail.

My patch fixes the bug, but requires adding `six` as a dependency. I'm open to alternative strategies, but I'm hoping you agree it ought to be fixed somehow. 

This does not address a separate bug, that the place is currently returned as `La Ca?ada Flintridge city, California` in Python 2 or 3 for 2016 and 2017 ACS data. 