### PR TITLE
Adds legislative districts + corrects census district name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,9 @@ ACS5 Geographies
 * state_county_subdivision(fields, state_fips, county_fips, subdiv_fips)
 * state_county_tract(fields, state_fips, county_fips, tract)
 * state_place(fields, state_fips, place)
-* state_district(fields, state_fips, district)
+* state_congressional_district(fields, state_fips, congressional_district)
+* state_legislative_district_upper(fields, state_fips, legislative_district)
+* state_legislative_district_lower(fields, state_fips, legislative_district)
 * us(fields)
 * zipcode(fields, zip5)
 
@@ -98,7 +100,7 @@ ACS1 Geographies
 ----------------
 
 * state(fields, state_fips)
-* state_district(fields, state_fips, district)
+* state_congressional_district(fields, state_fips, district)
 * us(fields)
 
 SF1 Geographies
@@ -109,7 +111,7 @@ SF1 Geographies
 * state_county_subdivision(fields, state_fips, county_fips, subdiv_fips)
 * state_county_tract(fields, state_fips, county_fips, tract)
 * state_place(fields, state_fips, place)
-* state_district(fields, state_fips, district)
+* state_congressional_district(fields, state_fips, district)
 * state_msa(fields, state_fips, msa)
 * state_csa(fields, state_fips, csa)
 * state_district_place(fields, state_fips, district, place)

--- a/census/core.py
+++ b/census/core.py
@@ -203,23 +203,35 @@ class Client(object):
         }, **kwargs)
 
     @supported_years()
-    def congressional_district(self, fields, state_fips, district, **kwargs):
+    def state_district(self, fields, state_fips, district, **kwargs):
+        warnings.warn(
+            "state_district refers to congressional districts; use state_congressional_district instead",
+             DeprecationWarning
+        )
+
+        # throwaway, but we can't pass it in twice.
+        congressional_district = kwargs.pop('congressional_district', None)
+        
+        return self.state_congressional_district(fields, state_fips, district)
+
+    @supported_years()
+    def state_congressional_district(self, fields, state_fips, congressional_district, **kwargs):
         return self.get(fields, geo={
-            'for': 'congressional district:{}'.format(district),
+            'for': 'congressional district:{}'.format(congressional_district),
             'in': 'state:{}'.format(state_fips),
         }, **kwargs)
 
     @supported_years()
-    def legislative_district_upper(self, fields, state_fips, district, **kwargs):
+    def state_legislative_district_upper(self, fields, state_fips, legislative_district, **kwargs):
         return self.get(fields, geo={
-            'for': 'state legislative district (upper chamber):{}'.format(str(district).zfill(3)),
+            'for': 'state legislative district (upper chamber):{}'.format(str(legislative_district).zfill(3)),
             'in': 'state:{}'.format(state_fips),
         }, **kwargs)
 
     @supported_years()
-    def legislative_district_lower(self, fields, state_fips, district, **kwargs):
+    def state_legislative_district_lower(self, fields, state_fips, legislative_district, **kwargs):
         return self.get(fields, geo={
-            'for': 'state legislative district (lower chamber):{}'.format(str(district).zfill(3)),
+            'for': 'state legislative district (lower chamber):{}'.format(str(legislative_district).zfill(3)),
             'in': 'state:{}'.format(state_fips),
         }, **kwargs)
 

--- a/census/core.py
+++ b/census/core.py
@@ -212,7 +212,7 @@ class Client(object):
         # throwaway, but we can't pass it in twice.
         congressional_district = kwargs.pop('congressional_district', None)
         
-        return self.state_congressional_district(fields, state_fips, district)
+        return self.state_congressional_district(fields, state_fips, district, **kwargs)
 
     @supported_years()
     def state_congressional_district(self, fields, state_fips, congressional_district, **kwargs):

--- a/census/core.py
+++ b/census/core.py
@@ -203,9 +203,23 @@ class Client(object):
         }, **kwargs)
 
     @supported_years()
-    def state_district(self, fields, state_fips, district, **kwargs):
+    def congressional_district(self, fields, state_fips, district, **kwargs):
         return self.get(fields, geo={
             'for': 'congressional district:{}'.format(district),
+            'in': 'state:{}'.format(state_fips),
+        }, **kwargs)
+
+    @supported_years()
+    def legislative_district_upper(self, fields, state_fips, district, **kwargs):
+        return self.get(fields, geo={
+            'for': 'state legislative district (upper chamber):{}'.format(str(district).zfill(3)),
+            'in': 'state:{}'.format(state_fips),
+        }, **kwargs)
+
+    @supported_years()
+    def legislative_district_lower(self, fields, state_fips, district, **kwargs):
+        return self.get(fields, geo={
+            'for': 'state legislative district (lower chamber):{}'.format(str(district).zfill(3)),
             'in': 'state:{}'.format(state_fips),
         }, **kwargs)
 

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -16,16 +16,20 @@ CLIENTS = (
     ('acs5', (
         'us', 'state', 'state_county', 'state_county_subdivision',
         'state_county_tract', 'state_county_blockgroup',
-        'state_place', 'state_district', 'zipcode',
+        'state_place', 'state_district',
+        'state_congressional_district',
+        'state_legislative_district_upper',
+        'state_legislative_district_lower', 'zipcode',
     )),
     ('acs1dp', (
-        'us', 'state', 'state_district',
+        'us', 'state', 'state_congressional_district',
     )),
     ('sf1', (
         'state', 'state_county', 'state_county_subdivision',
         'state_county_tract', 'state_county_blockgroup',
-        'state_place', 'state_district', 'state_msa', 'state_csa',
-        'state_district_place', 'state_zipcode',
+        'state_place', 'state_congressional_district', 
+        'state_msa', 'state_csa', 'state_district_place',
+        'state_zipcode',
     )),
     ('sf3', (
         'state', 'state_county', 'state_county_tract',
@@ -40,7 +44,9 @@ TEST_DATA = {
     'tract': '700704',
     'blockgroup': '1',
     'place': '31175',
-    'district': '06',
+    'district': '06',       # for old `state_district` calling.
+    'congressional_district': '06',
+    'legislative_district': '07',
     'zcta': '20877',
     'msa': '47900',
     'csa': '548',
@@ -151,6 +157,12 @@ class TestEndpoints(CensusTestCase):
             ('state_place', 'Gaithersburg city, Maryland'),
             ('state_district',
                 'Congressional District 6 (115th Congress), Maryland'),
+            ('state_congressional_district',
+                'Congressional District 6 (115th Congress), Maryland'),
+            ('state_legislative_district_upper',
+                'State Senate District 7 (2016), Maryland'),
+            ('state_legislative_district_lower',
+                'State Legislative District 7 (2016), Maryland'),
             ('zipcode', 'ZCTA5 20877'),
         )
 
@@ -161,7 +173,7 @@ class TestEndpoints(CensusTestCase):
         tests = (
             ('us', 'United States'),
             ('state', 'Maryland'),
-            ('state_district',
+            ('state_congressional_district',
                 'Congressional District 6 (115th Congress), Maryland'),
         )
 
@@ -177,7 +189,8 @@ class TestEndpoints(CensusTestCase):
                 'Census Tract 7007.04'),
             ('state_county_blockgroup', 'Block Group 1'),
             ('state_place', 'Gaithersburg city'),
-            ('state_district', 'Congressional District 6'),
+            ('state_congressional_district',
+                'Congressional District 6'),
             ('state_msa',
                 ('Washington-Arlington-Alexandria, '
                     'DC-VA-MD-WV Metro Area (part)')),


### PR DESCRIPTION
I had assumed `state_district` might refer to state house / state senate districts, but turns out it was congressional districts under the hood. So I added the two legislative district categories and moved the congressional district over to `congressional_district`.

I haven't updated the tests yet but if you all are open to this scheme, I can doctor up those and the README too. Feedback welcome on all fronts.