### PR TITLE
Provide support for ACS5 Subject Tables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,7 @@ Datasets
 ========
 
 * acs5: ACS 5 Year Estimates (2016, 2015, 2014, 2013, 2012, 2011, 2010)
+* acs5subject: ACS 5 Year Estimate Subject Tables (2016, 2015, 2014, 2013, 2012, 2011, 2010) 
 * acs1dp: ACS 1 Year Estimates, Data Profiles (2016, 2015, 2014, 2013, 2012)
 * sf1: Census Summary File 1 (2010, 2000, 1990)
 * sf3: Census Summary File 3 (2000, 1990)

--- a/census/core.py
+++ b/census/core.py
@@ -299,6 +299,12 @@ class ACS5DpClient(ACS5Client):
 
     years = (2016, 2015, 2014, 2013, 2012)
 
+class ACS5SubjectClient(ACS5Client):
+    
+    dataset = 'acs/acs5/subject'
+
+    years = (2016, 2015, 2014, 2013, 2012, 2011, 2010)
+
 
 class ACS3Client(ACSClient):
 
@@ -455,6 +461,7 @@ class Census(object):
         self.acs5dp = ACS5DpClient(key, year, session)
         self.acs3dp = ACS3DpClient(key, year, session)
         self.acs1dp = ACS1DpClient(key, year, session)
+        self.acs5subject = ACS5SubjectClient(key, year, session)
         self.sf1 = SF1Client(key, year, session)
         self.sf3 = SF3Client(key, year, session)
 


### PR DESCRIPTION
This would allow support for the ACS5 Subject Tables via the `https://api.census.gov/data/<year>/acs/acs5/subject/` endpoints.
