### PR TITLE
Provide support for ACS5 Subject Tables 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ For each dataset, the first year listed is the default.
 * acs5dp: `ACS 5 Year Estimates, Data Profiles  <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * acs3dp: `ACS 3 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-3year.html>`_ (2013, 2012)
 * acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2017, 2016, 2015, 2014, 2013, 2012, 2011)
+* acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010)
 * sf1: `Census Summary File 1 <https://www.census.gov/data/datasets/2010/dec/summary-file-1.html>`_ (2010, 2000, 1990)
 * sf3: `Census Summary File 3 <https://www.census.gov/census2000/sumfile3.html>`_ (2000, 1990)
 

--- a/census/core.py
+++ b/census/core.py
@@ -345,7 +345,7 @@ class ACS5DpClient(ACS5Client):
 
 class ACS5SubjectClient(ACS5Client):
 
-    dataset = 'acs/acs5/subject'
+    dataset = 'acs5/subject'
 
     years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)
     

--- a/census/core.py
+++ b/census/core.py
@@ -343,7 +343,7 @@ class ACS5DpClient(ACS5Client):
 
     years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
-class ACS5SubjectClient(ACS5Client):
+class ACS5StClient(ACS5Client):
     def _switch_endpoints(self, year):
         self.endpoint_url = 'https://api.census.gov/data/%s/acs/%s'
         self.definitions_url = 'https://api.census.gov/data/%s/acs/%s/variables.json'
@@ -527,7 +527,7 @@ class Census(object):
         self.acs5 = ACS5Client(key, year, session)
         self.acs3 = ACS3Client(key, year, session)
         self.acs1 = ACS1Client(key, year, session)
-        self.acs5subject = ACS5SubjectClient(key, year, session)
+        self.acs5st = ACS5StClient(key, year, session)
         self.acs5dp = ACS5DpClient(key, year, session)
         self.acs3dp = ACS3DpClient(key, year, session)
         self.acs1dp = ACS1DpClient(key, year, session)

--- a/census/core.py
+++ b/census/core.py
@@ -343,7 +343,12 @@ class ACS5DpClient(ACS5Client):
 
     years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
+class ACS5SubjectClient(ACS5Client):
 
+    dataset = 'acs/acs5/subject'
+
+    years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)
+    
 class ACS3Client(ACSClient):
 
     default_year = 2013
@@ -518,6 +523,7 @@ class Census(object):
         self.acs5 = ACS5Client(key, year, session)
         self.acs3 = ACS3Client(key, year, session)
         self.acs1 = ACS1Client(key, year, session)
+        self.acs5subject = ACS5SubjectClient(key, year, session)
         self.acs5dp = ACS5DpClient(key, year, session)
         self.acs3dp = ACS3DpClient(key, year, session)
         self.acs1dp = ACS1DpClient(key, year, session)

--- a/census/core.py
+++ b/census/core.py
@@ -344,7 +344,11 @@ class ACS5DpClient(ACS5Client):
     years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
 class ACS5SubjectClient(ACS5Client):
-
+    def _switch_endpoints(self, year):
+        self.endpoint_url = 'https://api.census.gov/data/%s/acs/%s'
+        self.definitions_url = 'https://api.census.gov/data/%s/acs/%s/variables.json'
+        self.definition_url = 'https://api.census.gov/data/%s/acs/%s/variables/%s.json'
+    
     dataset = 'acs5/subject'
 
     years = (2018, 2017, 2016, 2015, 2014, 2013, 2012)

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -74,6 +74,11 @@ class TestUnsupportedYears(CensusTestCase):
         client = self.client('acs5')
         self.assertRaises(UnsupportedYearException,
                           client.state, ('NAME', '06'))
+        
+    def test_acs5st(self):
+        client = self.client('acs5st')
+        self.assertRaises(UnsupportedYearException,
+                          client.state, ('NAME', '06'))
 
     def test_acs1dp(self):
         client = self.client('acs1dp')
@@ -171,7 +176,7 @@ class TestEndpoints(CensusTestCase):
 
         self.check_endpoints('acs5', tests)
 
-    def test_acs1dp(self):
+    def test_acs5st(self):
 
         tests = (
             ('us', 'United States'),
@@ -181,6 +186,18 @@ class TestEndpoints(CensusTestCase):
         )
 
         self.check_endpoints('acs1dp', tests)
+    
+    def test_acs1dp(self):
+
+        tests = (
+            ('us', 'United States'),
+            ('state', 'Maryland'),
+            ('state_congressional_district',
+                'Congressional District 6 (116th Congress), Maryland'),
+        )
+
+        self.check_endpoints('acs5st', tests)
+
 
     def test_sf1(self):
 

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -185,7 +185,7 @@ class TestEndpoints(CensusTestCase):
                 'Congressional District 6 (116th Congress), Maryland'),
         )
 
-        self.check_endpoints('acs1dp', tests)
+        self.check_endpoints('acs5st', tests)
     
     def test_acs1dp(self):
 
@@ -196,7 +196,7 @@ class TestEndpoints(CensusTestCase):
                 'Congressional District 6 (116th Congress), Maryland'),
         )
 
-        self.check_endpoints('acs5st', tests)
+        self.check_endpoints('acs1dp', tests)
 
 
     def test_sf1(self):


### PR DESCRIPTION
The code for this pull request comes from @grahamalama . I simply made a small edit to the dataset variable to change it to acs5/subject as it and pulled the latest version of census before making these changes. I've tested the subject client personally on my own project and it appears to work just fine. The reason I am submitting this pull request is because #60 is held up with merge conflicts in the README and is out of date/has one error related to the dataset variable. All credit should go to @grahamalama though