### PR TITLE
Sort API results by GEO_ID

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -152,21 +152,28 @@ class Client(object):
     def get(self, fields, geo, year=None, **kwargs):
         """
         The API only accepts up to 50 fields on each query.
-        Edit the original function to include the GEO_ID in each chunk,
-        which we use to sort the results by GEO_ID in query().
+        Chunk requests, and use the unique GEO_ID to match up the chunks
+        in case the responses are in different orders.
+        GEO_ID is not reliably present in pre-2010 requests.
         """
-        all_results = (self.query(forty_nine_fields + ['GEO_ID'], geo, year, **kwargs)
+        sort_by_geoid = len(fields) > 49 and (not year or year > 2009)
+        all_results = (self.query(forty_nine_fields, geo, year, sort_by_geoid=sort_by_geoid, **kwargs)
                        for forty_nine_fields in chunks(fields, 49))
         merged_results = [merge(result) for result in zip(*all_results)]
 
         return merged_results
 
     @retry_on_transient_error
-    def query(self, fields, geo, year=None, **kwargs):
+    def query(self, fields, geo, year=None, sort_by_geoid=False, **kwargs):
         if year is None:
             year = self.default_year
 
         fields = list_or_str(fields)
+        if sort_by_geoid:
+            if isinstance(fields, list):
+                fields += ['GEO_ID']
+            elif isinstance(fields, tuple):
+                fields += ('GEO_ID',)
 
         url = self.endpoint_url % (year, self.dataset)
 
@@ -196,7 +203,11 @@ class Client(object):
                         for header, cast, item
                         in zip(headers, types, d)}
                        for d in data]
-            results = sorted(results, key=lambda x: x['GEO_ID'])
+            if sort_by_geoid:
+                if 'GEO_ID' in fields:
+                    results = sorted(results, key=lambda x: x['GEO_ID'])
+                else:
+                    results = sorted(results, key=lambda x: x.pop('GEO_ID'))
             return results
 
         elif resp.status_code == 204:

--- a/census/core.py
+++ b/census/core.py
@@ -150,8 +150,13 @@ class Client(object):
         return data
 
     def get(self, fields, geo, year=None, **kwargs):
-        all_results = (self.query(fifty_fields, geo, year, **kwargs)
-                       for fifty_fields in chunks(fields, 50))
+        """
+        The API only accepts up to 50 fields on each query.
+        Edit the original function to include the GEO_ID in each chunk,
+        which we use to sort the results by GEO_ID in query().
+        """
+        all_results = (self.query(forty_nine_fields + ['GEO_ID'], geo, year, **kwargs)
+                       for forty_nine_fields in chunks(fields, 49))
         merged_results = [merge(result) for result in zip(*all_results)]
 
         return merged_results
@@ -191,6 +196,7 @@ class Client(object):
                         for header, cast, item
                         in zip(headers, types, d)}
                        for d in data]
+            results = sorted(results, key=lambda x: x['GEO_ID'])
             return results
 
         elif resp.status_code == 204:

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -264,6 +264,37 @@ class TestEndpoints(CensusTestCase):
         client = self.client('acs5')
         results = client.us(fields)
         assert set(results[0].keys()).issuperset(fields)
+    
+    def test_more_than_50_not_out_of_order(self):
+        fields = ['GEO_ID', 'B01001_001E', 'B01001_003E',
+                  'B01001_006E', 'B01001_007E', 'B01001_008E',
+                  'B01001_009E', 'B01001_010E', 'B01001_011E',
+                  'B01001_012E', 'B01001_013E', 'B01001_014E',
+                  'B01001_015E', 'B01001_016E', 'B01001_017E',
+                  'B01001_018E', 'B01001_019E', 'B01001_020E',
+                  'B01001_021E', 'B01001_022E', 'B01001_023E',
+                  'B01001_024E', 'B01001_025E', 'B01001_027E',
+                  'B01001_028E', 'B01001_029E', 'B01001_030E',
+                  'B01001_031E', 'B01001_032E', 'B01001_033E',
+                  'B01001_034E', 'B01001_035E', 'B01001_036E',
+                  'B01001_037E', 'B01001_038E', 'B01001_039E',
+                  'B01001_040E', 'B01001_041E', 'B01001_042E',
+                  'B01001_043E', 'B01001_044E', 'B01001_045E',
+                  'B01001_046E', 'B01001_047E', 'B01001_048E',
+                  'B01001_049E', 'B19001_003E', 'B19001_004E',
+                  'B19001_005E', 'B19001_006E', 'B19001_007E',
+                  'B19001_008E', 'B19001_009E', 'B19001_010E',
+                  'B19001_011E', 'B19001_012E', 'B19001_013E',
+                  'B19001_014E', 'B19001_015E', 'B19001_016E',
+                  'B03002_001E', ]
+
+        client = self.client('acs1')
+        results = client.state_county(fields, '*', '*', year=2018)
+        # We know that the last 5 digits of the GEO_ID are the FIPS code
+        # GEO_ID is grabbed in the first chunk (request), but the state and county are overwritten
+        # with each chunk and have the values from the last chunk
+        assert results[0]['GEO_ID'][-5:] == results[0]['state'] + \
+            results[0]['county']
 
     def test_new_style_endpoints(self):
         client = Census(KEY, year=2016)


### PR DESCRIPTION
It looks like the order in which the API returns results is not fixed, which was an assumption underlying the `Client.get()` method. See https://github.com/datamade/census/issues/98. 

Compare (using 2018 data, county level):
* [First 50 fields](https://api.census.gov/data/2018/acs/acs1?get=NAME,GEO_ID,B01001_001E,B01001_002E,B01001_003E,B01001_004E,B01001_005E,B01001_006E,B01001_007E,B01001_008E,B01001_009E,B01001_010E,B01001_011E,B01001_012E,B01001_013E,B01001_014E,B01001_015E,B01001_016E,B01001_017E,B01001_018E,B01001_019E,B01001_020E,B01001_021E,B01001_022E,B01001_023E,B01001_024E,B01001_025E,B01001_026E,B01001_027E,B01001_028E,B01001_029E,B01001_030E,B01001_031E,B01001_032E,B01001_033E,B01001_034E,B01001_035E,B01001_036E,B01001_037E,B01001_038E,B01001_039E,B01001_040E,B01001_041E,B01001_042E,B01001_043E,B01001_044E,B01001_045E,B01001_046E,B01001_047E&for=county:*&in=state:*) - first result is Adams County, CO, FIPS `08001`
* [Next 50 fields](https://api.census.gov/data/2018/acs/acs1?get=B01001_048E,B01001_049E,B25046_001E,B01001_001M,B01001_002M,B01001_003M,B01001_004M,B01001_005M,B01001_006M,B01001_007M,B01001_008M,B01001_009M,B01001_010M,B01001_011M,B01001_012M,B01001_013M,B01001_014M,B01001_015M,B01001_016M,B01001_017M,B01001_018M,B01001_019M,B01001_020M,B01001_021M,B01001_022M,B01001_023M,B01001_024M,B01001_025M,B01001_026M,B01001_027M,B01001_028M,B01001_029M,B01001_030M,B01001_031M,B01001_032M,B01001_033M,B01001_034M,B01001_035M,B01001_036M,B01001_037M,B01001_038M,B01001_039M,B01001_040M,B01001_041M,B01001_042M,B01001_043M,B01001_044M,B01001_045M,B01001_046M&for=county:*&in=state:*) - first result is Baldwin County, AL, FIPS `01003`

So when you `merge` these results together, you're matching the first fifty fields of Adams County with the first fifty fields of Baldwin County. 

I don't remember this being a problem in past years (and the code in question in this repo hasn't changed in 4 years) but it's happening with both 2018 and 2019 API queries. Maybe the Census changed something subtle on their end? I emailed them to ask. 

Although every result has some auto-generated fields like `state` and `county`, those change depending on what geographic layer you requsted. Instead, this fix uses the `GEO_ID`, which is guaranteed to be present and unique (as far as I know) for every geography.

Questions this solution raises:
* Is it okay to enforce sorting on all requests, or should it be opt-in?
* Is it okay to add `GEO_ID` to every client request? Should we remove it after sorting if they didn't request it? Personally I think it's best practice to have a unique ID on your downloaded data. 
* Are there any compatibility issues raised by increasing the number of chunks requested (100 fields now requires 3 requests, not 2)?
* Does this code raise any other compatibility issues?