### PR TITLE
Add support for redistricting data (PLClient)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ For each dataset, the first year listed is the default.
 * acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
 * acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * sf1: `Census Summary File 1 <https://www.census.gov/data/datasets/2010/dec/summary-file-1.html>`_ (2010)
+* pl: `Redistricing Data Summary File <https://www.census.gov/programs-surveys/decennial-census/about/rdo/summary-files.2020.html>`_ (2020, 2010, 2000) 
 
 
 Geographies
@@ -123,6 +124,18 @@ SF1 Geographies
 * state_district_place(fields, state_fips, district, place)
 * state_zipcode(fields, state_fips, zip5)
 
+PL Geographies
+--------------
+
+* state(fields, state_fips)
+* state_county(fields, state_fips, county_fips)
+* state_county_subdivision(fields, state_fips, county_fips, subdiv_fips)
+* state_county_tract(fields, state_fips, county_fips, tract)
+* state_county_blockgroup(fields, state_fips, county_fips, blockgroup)
+* state_place(fields, state_fips, place)
+* state_congressional_district(fields, state_fips, district)
+* state_legislative_district_upper(fields, state_fips, legislative_district)
+* state_legislative_district_lower(fields, state_fips, legislative_district)
 
 States
 ======

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -32,13 +32,20 @@ CLIENTS = (
         'state', 'state_county', 'state_county_tract',
         'state_county_blockgroup', 'state_place',
     )),
+    ('pl', (
+        'us', 'state', 'state_county', 'state_county_subdivision',
+        'state_county_tract', 'state_county_blockgroup',
+        'state_place', 'state_congressional_district',
+        'state_legislative_district_upper',
+        'state_legislative_district_lower',
+    ))
 )
 
 TEST_DATA = {
     'state_fips': '24',
     'county_fips': '031',
     'subdiv_fips': '90796',
-    'tract': '700704',
+    'tract': '700706',
     'blockgroup': '1',
     'place': '31175',
     'district': '06',       # for old `state_district` calling.
@@ -83,6 +90,11 @@ class TestUnsupportedYears(CensusTestCase):
                           client.state, ('NAME', '06'))
 
     def test_sf1(self):
+        client = self.client('sf1')
+        self.assertRaises(UnsupportedYearException,
+                          client.state, ('NAME', '06'))
+
+    def test_pl(self):
         client = self.client('sf1')
         self.assertRaises(UnsupportedYearException,
                           client.state, ('NAME', '06'))
@@ -141,6 +153,7 @@ class TestEndpoints(CensusTestCase):
         self.client('acs5').tables()
         self.client('acs5').tables(2010)
         self.client('sf1').tables()
+        self.client('pl').tables()
 
     def test_acs5(self):
 
@@ -151,9 +164,9 @@ class TestEndpoints(CensusTestCase):
             ('state_county_subdivision',
                 'District 9, Montgomery County, Maryland'),
             ('state_county_tract',
-                'Census Tract 7007.04, Montgomery County, Maryland'),
+                'Census Tract 7007.06, Montgomery County, Maryland'),
             ('state_county_blockgroup',
-                ('Block Group 1, Census Tract 7007.04, '
+                ('Block Group 1, Census Tract 7007.06, '
                     'Montgomery County, Maryland')),
             ('state_place', 'Gaithersburg city, Maryland'),
             ('state_district',
@@ -199,9 +212,9 @@ class TestEndpoints(CensusTestCase):
             ('state_county_subdivision',
                 ('District 9, Montgomery County, Maryland')),
             ('state_county_tract',
-                'Census Tract 7007.04, Montgomery County, Maryland'),
+                'Census Tract 7007.06, Montgomery County, Maryland'),
             ('state_county_blockgroup',
-                ('Block Group 1, Census Tract 7007.04, '
+                ('Block Group 1, Census Tract 7007.06, '
                  'Montgomery County, Maryland')),
             ('state_place', 'Gaithersburg city, Maryland'),
             ('state_congressional_district',
@@ -217,6 +230,32 @@ class TestEndpoints(CensusTestCase):
         )
 
         self.check_endpoints('sf1', tests)
+
+    def test_pl(self):
+
+        tests = (
+            ('us', 'United States'),
+            ('state', 'Maryland'),
+            ('state_county', 'Montgomery County, Maryland'),
+            ('state_county_subdivision',
+                'District 9, Montgomery County, Maryland'),
+            ('state_county_tract',
+                'Census Tract 7007.06, Montgomery County, Maryland'),
+            ('state_county_blockgroup',
+                ('Block Group 1, Census Tract 7007.06, '
+                    'Montgomery County, Maryland')),
+            ('state_place', 'Gaithersburg city, Maryland'),
+            ('state_district',
+                'Congressional District 6, Maryland'),
+            ('state_congressional_district',
+                'Congressional District 6, Maryland'),
+            ('state_legislative_district_upper',
+                'State Senate District 7 (2018), Maryland'),
+            ('state_legislative_district_lower',
+                'State Legislative District 7, Maryland'),
+        )
+
+        self.check_endpoints('pl', tests)
 
     def test_more_than_50(self):
         fields = ['B01001_003E', 'B01001_004E', 'B01001_005E',


### PR DESCRIPTION
### _**Note: Build will fail due to #104**_

<br>
Resolves #107 

### Changes
- Adds `PLClient` for redistricting data
- Adds tests for `PLClient`
- Adds documentation for `PLClient`
- Updates `TEST_DATA` for global parameters across all tests
  - `{'tract': 700704}` -> `{'tract': 700706}`