### PR TITLE
Added a link to the Census Data API User Guide to the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ The default year may also be set client-wide::
     c = Census("MY_API_KEY", year=2010)
 
 
+Detailed information about the API can be found at the `Census Data API User Guide <https://www.census.gov/data/developers/guidance/api-user-guide.html>`_.
+
 Datasets
 ========
 


### PR DESCRIPTION
#80
#81 

To help users gain a better understanding of the API itself, I added a link to the Census Bureau's Census Data API User Guide in the readme.  The additional details that the guide provides make it easier to learn the workings of the API and utilize this tool.