### PR TITLE
Add 2021 ACS support

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -315,10 +315,10 @@ class ACSClient(Client):
 
 class ACS5Client(ACSClient):
 
-    default_year = 2020
+    default_year = 2021
     dataset = 'acs5'
 
-    years = (2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+    years = (2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,
@@ -347,7 +347,7 @@ class ACS5Client(ACSClient):
             geo['in'] += ' tract:{}'.format(tract)
         return self.get(fields, geo=geo, **kwargs)
 
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    @supported_years(2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
     def zipcode(self, fields, zcta, **kwargs):
         warnings.warn(
             "zipcode has been deprecated; use state_zipcode instead",
@@ -358,7 +358,7 @@ class ACS5Client(ACSClient):
 
         return self.state_zipcode(fields, state_fips, zcta, **kwargs)
 
-    @supported_years(2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    @supported_years(2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
     def state_zipcode(self, fields, state_fips, zcta, **kwargs):
         year = kwargs.get('year', self.default_year)
         geo = {
@@ -410,10 +410,10 @@ class ACS3DpClient(ACS3Client):
 
 class ACS1Client(ACSClient):
 
-    default_year = 2019
+    default_year = 2021
     dataset = 'acs1'
 
-    years = (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,
@@ -428,7 +428,7 @@ class ACS1DpClient(ACS1Client):
 
     dataset = 'acs1/profile'
 
-    years = (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
+    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
 
 class SF1Client(Client):


### PR DESCRIPTION
Excluded year 2020 for ACS1 because Census Bureau did not release its standard ACS 1-year estimates for 2020 due to COVID-19. 2021 ACS1 estimates are available. 