### PR TITLE
Update python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
I did some digging and it looked like maybe the workflows need to be updated, possibly due to the switch to Node16 instead of Node12 (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). It looked like the workflows were failing to even install python before running any tests on the package code.

I don't know anything about the workflows or how to test if this fixes anything. I just changed a few things based on the starter workflow from github's python package guide (https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python).

Edit: the workflows failing in (https://github.com/datamade/census/pull/126) had errors about not finding python versions and warnings about the deprecation. I think the changes I am suggesting only address the warnings, not the errors.

Edit 2: based on this comment/thread (https://github.com/actions/setup-python/issues/162#issuecomment-1344117224), the python 3.5 and 3.6 errors might be related to the `runs-on:ubuntu-latest` setting, as 3.5 and 3.6 don't include files for ubuntu version 22.04 (in the list of available versions https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json). 