### PR TITLE
Adding 2021 to available years for ACS1Client and ACS5Client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,13 @@ Datasets
 
 For each dataset, the first year listed is the default.
 
-* acs5: `ACS 5 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs5: `ACS 5 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * acs3: `ACS 3 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-3year.html>`_ (2013, 2012)
-* acs1: `ACS 1 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
-* acs5dp: `ACS 5 Year Estimates, Data Profiles  <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs1: `ACS 1 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+* acs5dp: `ACS 5 Year Estimates, Data Profiles  <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * acs3dp: `ACS 3 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-3year.html>`_ (2013, 2012)
-* acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
-* acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+* acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * sf1: `Census Summary File 1 <https://www.census.gov/data/datasets/2010/dec/summary-file-1.html>`_ (2010)
 * pl: `Redistricting Data Summary File <https://www.census.gov/programs-surveys/decennial-census/about/rdo/summary-files.2020.html>`_ (2020, 2010, 2000) 
 

--- a/census/core.py
+++ b/census/core.py
@@ -293,7 +293,7 @@ class ACSClient(Client):
 
     def _switch_endpoints(self, year):
 
-        if year > 2009:
+        if year >= 2005:
             self.endpoint_url = 'https://api.census.gov/data/%s/acs/%s'
             self.definitions_url = 'https://api.census.gov/data/%s/acs/%s/variables.json'
             self.definition_url = 'https://api.census.gov/data/%s/acs/%s/variables/%s.json'

--- a/census/core.py
+++ b/census/core.py
@@ -96,6 +96,7 @@ class Client(object):
     groups_url = 'https://api.census.gov/data/%s/%s/groups.json'
 
     def __init__(self, key, year=None, session=None, retries=3):
+        self.dataset = None
         self._key = key
         self.session = session or new_session()
         if year:
@@ -410,10 +411,10 @@ class ACS3DpClient(ACS3Client):
 
 class ACS1Client(ACSClient):
 
-    default_year = 2019
+    default_year = 2021
     dataset = 'acs1'
 
-    years = (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,
@@ -428,7 +429,7 @@ class ACS1DpClient(ACS1Client):
 
     dataset = 'acs1/profile'
 
-    years = (2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
+    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
 
 class SF1Client(Client):

--- a/census/core.py
+++ b/census/core.py
@@ -414,7 +414,7 @@ class ACS1Client(ACSClient):
     default_year = 2021
     dataset = 'acs1'
 
-    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+requests>=2.31
 pytest>=2.9


### PR DESCRIPTION
Census 1 Year and 5 Year APIs have 2021 data available.

Census 1 Year Data for 2020 will not be released due to COVID interruptions in their data gathering.