### PR TITLE
Add support for 2022 ACS Data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,13 +67,13 @@ Datasets
 
 For each dataset, the first year listed is the default.
 
-* acs5: `ACS 5 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs5: `ACS 5 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * acs3: `ACS 3 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-3year.html>`_ (2013, 2012)
-* acs1: `ACS 1 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
-* acs5dp: `ACS 5 Year Estimates, Data Profiles  <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs1: `ACS 1 Year Estimates <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+* acs5dp: `ACS 5 Year Estimates, Data Profiles  <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * acs3dp: `ACS 3 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-3year.html>`_ (2013, 2012)
-* acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
-* acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+* acs1dp: `ACS 1 Year Estimates, Data Profiles <https://www.census.gov/data/developers/data-sets/acs-1year.html>`_ (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+* acs5st: `ACS 5 Year Estimates, Subject Tables <https://www.census.gov/data/developers/data-sets/acs-5year.html>`_ (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 * sf1: `Census Summary File 1 <https://www.census.gov/data/datasets/2010/dec/summary-file-1.html>`_ (2010)
 * pl: `Redistricting Data Summary File <https://www.census.gov/programs-surveys/decennial-census/about/rdo/summary-files.2020.html>`_ (2020, 2010, 2000) 
 

--- a/census/core.py
+++ b/census/core.py
@@ -291,6 +291,13 @@ class Client(object):
         return self.get(fields, geo={
             'for': 'combined statistical area:{}'.format(str(csa)),
         }, **kwargs)
+    
+    @supported_years()
+    def msa(self, fields, msa, **kwargs):
+        return self.get(fields, geo={
+            'for': ('metropolitan statistical area/' +
+                'micropolitan statistical area:{}'.format(msa)), 
+        }, **kwargs)
 
 class ACSClient(Client):
 

--- a/census/core.py
+++ b/census/core.py
@@ -319,10 +319,10 @@ class ACSClient(Client):
 
 class ACS5Client(ACSClient):
 
-    default_year = 2021
+    default_year = 2022
     dataset = 'acs5'
 
-    years = (2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
+    years = (2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,
@@ -351,7 +351,7 @@ class ACS5Client(ACSClient):
             geo['in'] += ' tract:{}'.format(tract)
         return self.get(fields, geo=geo, **kwargs)
 
-    @supported_years(2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
     def zipcode(self, fields, zcta, **kwargs):
         warnings.warn(
             "zipcode has been deprecated; use state_zipcode instead",
@@ -362,7 +362,7 @@ class ACS5Client(ACSClient):
 
         return self.state_zipcode(fields, state_fips, zcta, **kwargs)
 
-    @supported_years(2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
+    @supported_years(2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011)
     def state_zipcode(self, fields, state_fips, zcta, **kwargs):
         year = kwargs.get('year', self.default_year)
         geo = {
@@ -414,10 +414,10 @@ class ACS3DpClient(ACS3Client):
 
 class ACS1Client(ACSClient):
 
-    default_year = 2021
+    default_year = 2022
     dataset = 'acs1'
 
-    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005)
+    years = (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005)
 
     @supported_years()
     def state_county_subdivision(self, fields, state_fips,
@@ -432,7 +432,7 @@ class ACS1DpClient(ACS1Client):
 
     dataset = 'acs1/profile'
 
-    years = (2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
+    years = (2022, 2021, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012)
 
 
 class SF1Client(Client):

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -50,7 +50,7 @@ TEST_DATA = {
     'place': '31175',
     'district': '06',       # for old `state_district` calling.
     'congressional_district': '06',
-    'legislative_district': '07',
+    'legislative_district': '06',
     'zcta': '20877',
     'msa': '47900',
     'csa': '548',
@@ -133,9 +133,6 @@ class TestEndpoints(CensusTestCase):
 
     def check_endpoints(self, client_name, tests, **kwargs):
 
-        if kwargs:
-            tests = ((k, kwargs.get(k, v)) for k, v in tests)
-
         client = self.client(client_name)
         fields = ('NAME',)
 
@@ -144,7 +141,7 @@ class TestEndpoints(CensusTestCase):
             msg = '{}.{}'.format(client_name, method_name)
 
             method = getattr(client, method_name)
-            data = method(fields, **TEST_DATA)
+            data = method(fields, **TEST_DATA, **kwargs)
             self.assertTrue(data, msg)
             self.assertEqual(data[0]['NAME'], expected, msg)
             time.sleep(0.2)
@@ -164,19 +161,19 @@ class TestEndpoints(CensusTestCase):
             ('state_county_subdivision',
                 'District 9, Montgomery County, Maryland'),
             ('state_county_tract',
-                'Census Tract 7007.06, Montgomery County, Maryland'),
+                'Census Tract 7007.06; Montgomery County; Maryland'),
             ('state_county_blockgroup',
-                ('Block Group 1, Census Tract 7007.06, '
-                    'Montgomery County, Maryland')),
+                ('Block Group 1; Census Tract 7007.06; '
+                    'Montgomery County; Maryland')),
             ('state_place', 'Gaithersburg city, Maryland'),
             ('state_district',
-                'Congressional District 6 (116th Congress), Maryland'),
+                'Congressional District 6 (118th Congress), Maryland'),
             ('state_congressional_district',
-                'Congressional District 6 (116th Congress), Maryland'),
+                'Congressional District 6 (118th Congress), Maryland'),
             ('state_legislative_district_upper',
-                'State Senate District 7 (2018), Maryland'),
+                'State Senate District 6 (2022), Maryland'),
             ('state_legislative_district_lower',
-                'State Legislative District 7 (2018), Maryland'),
+                'State Legislative District 6 (2022), Maryland'),
             ('state_zipcode', 'ZCTA5 20877'),
         )
 
@@ -201,9 +198,9 @@ class TestEndpoints(CensusTestCase):
             ('state_congressional_district',
                 'Congressional District 6 (116th Congress), Maryland'),
             ('state_legislative_district_upper',
-                'State Senate District 7 (2018), Maryland'),
+                'State Senate District 6 (2018), Maryland'),
             ('state_legislative_district_lower',
-                'State Legislative District 7 (2018), Maryland'),
+                'State Legislative District 6 (2018), Maryland'),
             ('state_zipcode', 'ZCTA5 20877'),
         )
 
@@ -215,7 +212,7 @@ class TestEndpoints(CensusTestCase):
             ('us', 'United States'),
             ('state', 'Maryland'),
             ('state_congressional_district',
-                'Congressional District 6 (116th Congress), Maryland'),
+                'Congressional District 6 (118th Congress), Maryland'),
         )
 
         self.check_endpoints('acs5st', tests)
@@ -226,7 +223,7 @@ class TestEndpoints(CensusTestCase):
             ('us', 'United States'),
             ('state', 'Maryland'),
             ('state_congressional_district',
-                'Congressional District 6 (116th Congress), Maryland'),
+                'Congressional District 6 (118th Congress), Maryland'),
         )
 
         self.check_endpoints('acs1dp', tests)
@@ -277,9 +274,9 @@ class TestEndpoints(CensusTestCase):
             ('state_congressional_district',
                 'Congressional District 6 (116th Congress), Maryland'),
             ('state_legislative_district_upper',
-                'State Senate District 7 (2018), Maryland'),
+                'State Senate District 6 (2018), Maryland'),
             ('state_legislative_district_lower',
-                'State Legislative District 7 (2018), Maryland'),
+                'State Legislative District 6 (2018), Maryland'),
         )
 
         self.check_endpoints('pl', tests)


### PR DESCRIPTION
- Added the year 2022 for ACS1 and ACS5
- Updated tests to reflect most recent year
- Had to change legislative district, for some reason ACS data is not available yet for maryland state district 7
- Bug fix for using kwargs in check_endpoints (previous year test was actually just retesting default year)