### PR TITLE
Bump to version 0.8.24

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,6 @@ authors:
   given-names: "Forest"
 - name: "Contributors"
 title: "census"
-version: 0.8.19
-date-released: 2022-07-14
+version: 0.8.24
+date-released: 2024-03-05
 url: "https://github.com/datamade/census"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = census
-version = 0.8.22
+version = 0.8.24
 author = Jeremy Carbaugh
 author_email = jcarbaugh@sunlightfoundation.com
 maintainer = Forest Gregg


### PR DESCRIPTION
Apply framework to bump version for 2023 ACS changes made in #151 ahead of next [pypi](https://pypi.org/project/census/) update by maintainers.