### PR TITLE
Update API key requirement for May 12, 2026 Census update and add error for users.

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -96,6 +96,11 @@ class Client(object):
     groups_url = 'https://api.census.gov/data/%s/%s/groups.json'
 
     def __init__(self, key, year=None, session=None, retries=3):
+        if key == "" or key is None:
+            raise ValueError(
+                "As of May 12, 2026, all requests to the US Census API require an API key. "
+                "You may acquire one at https://api.census.gov/data/key_signup.html"
+            )
         self._key = key
         self.session = session or new_session()
         if year:
@@ -112,7 +117,7 @@ class Client(object):
 
         # Query the table metadata as raw JSON
         tables_url = self.groups_url % (year, self.dataset)
-        resp = self.session.get(tables_url)
+        resp = self.session.get(tables_url, params={"key": self._key})
 
         # Pass it out
         return resp.json()['groups']
@@ -126,7 +131,7 @@ class Client(object):
 
         fields_url = self.definitions_url % (year, self.dataset)
 
-        resp = self.session.get(fields_url)
+        resp = self.session.get(fields_url, params={"key": self._key})
         obj = resp.json()
 
         if flat:

--- a/census/core.py
+++ b/census/core.py
@@ -216,7 +216,7 @@ class Client(object):
     @lru_cache(maxsize=1024)
     def _field_type(self, field, year):
         url = self.definition_url % (year, self.dataset, field)
-        resp = self.session.get(url)
+        resp = self.session.get(url, params={"key": self._key})
 
         types = {"fips-for": str,
                  "fips-in": str,
@@ -581,6 +581,11 @@ class Census(object):
     ALL = ALL
 
     def __init__(self, key, year=None, session=None):
+        if key == "" or key is None:
+            raise ValueError(
+                "As of May 12, 2026, all requests to the US Census API require an API key. "
+                "You may acquire one at https://api.census.gov/data/key_signup.html"
+            )
 
         if not session:
             session = new_session()

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -5,7 +5,7 @@ import time
 import unittest
 
 from census.core import (
-    Census, UnsupportedYearException)
+    Census, Client, UnsupportedYearException)
 
 KEY = os.environ.get('CENSUS_KEY', '')
 
@@ -383,6 +383,21 @@ class TestEndpoints(CensusTestCase):
             year=2000,
         )
         assert result_2010 != result_2000
+
+
+class TestAPIKeyRequired(unittest.TestCase):
+
+    def test_census_raises_without_key(self):
+        with self.assertRaises(ValueError):
+            Census(None)
+        with self.assertRaises(ValueError):
+            Census("")
+
+    def test_client_raises_without_key(self):
+        with self.assertRaises(ValueError):
+            Client(None)
+        with self.assertRaises(ValueError):
+            Client("")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey! Just adding this here in case it helps. Please let me know if there is a better branch to open this PR against (I didn't see any notes on contributing that specified).

This is a quick patch to a bug flagged in #165. As of today, the US Census Bureau now requires all requests made against its API carry an API key. But when calling 

```python
census = Census(key="<API_KEY>")
```

the API key was not always forwarded to requests. This PR adds modifies the `_field_type` cache to add in the API key and adds a warning to users that the key is now required.

This also patches the `fields` and `tables` requests and adds a test to make sure that you have passed an API key to the Client.