### PR TITLE
Switch ACS/SF1/PL endpoints on fields() too

### DIFF
--- a/census/core.py
+++ b/census/core.py
@@ -324,6 +324,10 @@ class ACSClient(Client):
         self._switch_endpoints(kwargs.get('year', self.default_year))
         return super(ACSClient, self).tables(*args, **kwargs)
 
+    def fields(self, *args, **kwargs):
+        self._switch_endpoints(kwargs.get('year', self.default_year))
+        return super(ACSClient, self).fields(*args, **kwargs)
+
     def get(self, *args, **kwargs):
         self._switch_endpoints(kwargs.get('year', self.default_year))
 
@@ -466,6 +470,10 @@ class SF1Client(Client):
         self._switch_endpoints(kwargs.get('year', self.default_year))
         return super(SF1Client, self).tables(*args, **kwargs)
 
+    def fields(self, *args, **kwargs):
+        self._switch_endpoints(kwargs.get('year', self.default_year))
+        return super(SF1Client, self).fields(*args, **kwargs)
+
     def get(self, *args, **kwargs):
         self._switch_endpoints(kwargs.get('year', self.default_year))
 
@@ -547,6 +555,10 @@ class PLClient(Client):
     def tables(self, *args, **kwargs):
         self._switch_endpoints(kwargs.get('year', self.default_year))
         return super(PLClient, self).tables(*args, **kwargs)
+
+    def fields(self, *args, **kwargs):
+        self._switch_endpoints(kwargs.get('year', self.default_year))
+        return super(PLClient, self).fields(*args, **kwargs)
 
     def get(self, *args, **kwargs):
         self._switch_endpoints(kwargs.get('year', self.default_year))

--- a/census/tests/test_census.py
+++ b/census/tests/test_census.py
@@ -152,6 +152,16 @@ class TestEndpoints(CensusTestCase):
         self.client('sf1').tables()
         self.client('pl').tables()
 
+    def test_fields(self):
+        # Regression for #138: fields() needs the same endpoint switch
+        # that tables() and get() do. Otherwise calling fields() before
+        # anything else on an ACS/SF1/PL client hits the wrong URL and
+        # 404s.
+        self.client('acs5').fields()
+        self.client('acs5').fields(2010)
+        self.client('sf1').fields()
+        self.client('pl').fields()
+
     def test_acs5(self):
 
         tests = (


### PR DESCRIPTION
`tables()` and `get()` on the ACS, SF1, and PL clients each wrap themselves with a `_switch_endpoints` call so the dataset-specific URLs are set before the request goes out. `fields()` doesn't, so it just inherits `Client.fields()` and hits whatever URL was set last (or the generic Census one), which 404s and the response fails to decode as JSON.

The reason it usually looks fine is that calling `tables()` first happens to set the endpoint as a side effect. Hitting `fields()` before anything else is the broken path \(@ptwales' repro in the issue).

Added the wrapper to all three clients that already had this pattern. Also added a `test_fields` test mirroring `test_tables`.

Closes #138.